### PR TITLE
Fix language switch menu background style

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -175,13 +175,13 @@ article tr.center {
 .langdropdown-items {
     display: none;
     position: absolute;
-    /*background-color: #f9f9f9;*/
+    background-color: #f2f2f2;
     min-width: 100%;
-    /*box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);*/
-    /*padding: 12px 16px;*/
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.1);
+    padding: 8px 16px;
     z-index: 1;
     overflow: auto;
-    right: 0;
+    /*right: 0;*/
 }
 .langdropdown:hover .langdropdown-items {
     display: block;


### PR DESCRIPTION
Background was transparent before, leading to hard reading.

Now, it is gray and the menu has a slight shadow.