### PR TITLE
Add a link to the official page to the "unverified translation" warning

### DIFF
--- a/_includes/translated-warning.html
+++ b/_includes/translated-warning.html
@@ -1,8 +1,5 @@
-{% assign urlpathparts = page.url | split: "/" %}
-{% assign currlangcode = urlpathparts[1] %}
-{% assign officialpage = page.url %}
-{% assign prefixtoremove = "/" | append: currlangcode %}
-{% assign officialpage = officialpage | remove_first: prefixtoremove %}
+{% assign posts = site.pages | concat: site.doc | concat: site.qubes-translated | where: 'ref', page.ref | where: 'lang', 'en' %}
+{% assign officialpage = posts[0].url %}
 <div class="alert alert-warning" role="alert">
   <i class="fa fa-exclamation-circle"></i>
   This page is an unverified translation.

--- a/_includes/translated-warning.html
+++ b/_includes/translated-warning.html
@@ -1,5 +1,11 @@
+{% assign urlpathparts = page.url | split: "/" %}
+{% assign currlangcode = urlpathparts[1] %}
+{% assign officialpage = page.url %}
+{% assign prefixtoremove = "/" | append: currlangcode %}
+{% assign officialpage = officialpage | remove_first: prefixtoremove %}
 <div class="alert alert-warning" role="alert">
   <i class="fa fa-exclamation-circle"></i>
   This page is an unverified translation.
   The Qubes OS Project cannot evaluate the accuracy of translations into languages that our team cannot read.
+  You may want to visit <a href="{{ officialpage }}">the official version of this page</a>.
 </div>


### PR DESCRIPTION
The "unverified translation" warning message could cause the need to go
to the official page. The problem here is that the visitor has to know
how to do that (select `en` (and nothing else)). This could be easier:
The warning message shows a link to the official version of the page.